### PR TITLE
Update call of get_token() in class Power_Bi

### DIFF
--- a/includes/class-power-bi-oauth.php
+++ b/includes/class-power-bi-oauth.php
@@ -77,7 +77,7 @@ class Power_Bi_Oauth {
         }
     }
 
-    public function get_token() {
+    public static function get_token() {
 
         $token_transient = get_transient( 't_token' );
 

--- a/includes/class-power-bi-oauth.php
+++ b/includes/class-power-bi-oauth.php
@@ -77,7 +77,7 @@ class Power_Bi_Oauth {
         }
     }
 
-    public static function get_token() {
+    public function get_token() {
 
         $token_transient = get_transient( 't_token' );
 

--- a/includes/class-power-bi.php
+++ b/includes/class-power-bi.php
@@ -89,7 +89,7 @@ if ( ! class_exists( 'Power_Bi' ) ) {
 		}
 
 		function get_powerbi_access_token() {
-			$returnObject = Power_Bi_Oauth::get_token();
+			$returnObject = Power_Bi_Oauth::get_instance()->get_token();
 			return $returnObject['access_token'];
 		}
 


### PR DESCRIPTION
Power_Bi_Oauth's  non-static function `get_token()` is used as a static function in Power_Bi's `get_powerbi_access_token()`.

https://github.com/atlaspolicy/power-bi-embedded/blob/4a7c9f06fc8378f8f65ba0ebd611d48961210ae6/includes/class-power-bi.php#L91-L94